### PR TITLE
[DO NOT MERGE] New AI behavior for travelling

### DIFF
--- a/AI/AIManager.cs
+++ b/AI/AIManager.cs
@@ -12,6 +12,8 @@ namespace CustomSpawns.AI
 
         public static HourlyPatrolAroundSpawnBehaviour HourlyPatrolAroundSpawn { get; set; }
 
+        public static HourlyGoToSettlementBehaviour HourlyGoToSettlement { get; set; }
+
         public static AttackClosestIfIdleForADayBehaviour AttackClosestIfIdleForADayBehaviour { get; set; }
 
         public static PatrolAroundClosestLestInterruptedAndSwitchBehaviour PatrolAroundClosestLestInterruptedAndSwitchBehaviour { get; set; }

--- a/AI/HourlyGoToSettlementBehavior.cs
+++ b/AI/HourlyGoToSettlementBehavior.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using CustomSpawns.Data;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
+
+namespace CustomSpawns.AI
+{
+    public class HourlyGoToSettlementBehaviour : CampaignBehaviorBase, IAIBehaviour
+    {
+        public override void RegisterEvents()
+        {
+            CampaignEvents.HourlyTickEvent.AddNonSerializedListener(this, HourlyCheckSettlementTick);
+            AIManager.HourlyGoToSettlement = this;
+        }
+
+        public override void SyncData(IDataStore dataStore)
+        {
+
+        }
+
+        private void HourlyCheckSettlementTick()
+        {
+            List<Traveller> toRemove = new List<Traveller>();
+            foreach (var traveller in registeredTravellers)
+            {
+                if (traveller.travellerParty == null || traveller.travellerParty.MemberRoster.Count == 0)
+                {
+                    //if party is dead, remove
+                    toRemove.Add(traveller);
+                    return;
+                }
+
+                bool isPreOccupied = traveller.travellerParty.DefaultBehavior == AiBehavior.EngageParty || traveller.travellerParty.DefaultBehavior == AiBehavior.GoAroundParty ||
+                     traveller.travellerParty.DefaultBehavior == AiBehavior.JoinParty || traveller.travellerParty.DefaultBehavior == AiBehavior.FleeToPoint;
+                if (!isPreOccupied)
+                {
+                    isPreOccupied = traveller.travellerParty.ShortTermBehavior == AiBehavior.EngageParty || traveller.travellerParty.ShortTermBehavior == AiBehavior.GoAroundParty ||
+                         traveller.travellerParty.ShortTermBehavior == AiBehavior.JoinParty || traveller.travellerParty.ShortTermBehavior == AiBehavior.FleeToPoint;
+                }
+                bool partyIsTraveling = traveller.travellerParty.IsGoingToSettlement;
+                if (!partyIsTraveling)
+                {
+                    partyIsTraveling = traveller.travellerParty.IsCurrentlyGoingToSettlement;
+                }
+                if (!partyIsTraveling)
+                {
+                    List<CultureCode> spawnSettlementCultureList = new List<CultureCode>();
+                    spawnSettlementCultureList.Add(traveller.homeSettlement.Culture.GetCultureCode());
+                    Settlement settlementGoingTo = CampaignUtils.PickRandomSettlementOfCulture(spawnSettlementCultureList);
+                    if (settlementGoingTo.IsRaided || settlementGoingTo.IsUnderSiege) // if settlement that it's pathing to is raided or under siege, change target
+                    {
+                        List<CultureCode> fallbackSettlementCultureList = new List<CultureCode>();
+                        fallbackSettlementCultureList.Add(traveller.homeSettlement.Culture.GetCultureCode());
+                        Settlement fallbackSettlement = CampaignUtils.PickRandomSettlementOfCulture(fallbackSettlementCultureList);
+                        traveller.travellerParty.SetMoveGoToSettlement(fallbackSettlement);
+                    }
+                    else if (!isPreOccupied)
+                    {
+                        traveller.travellerParty.SetMoveGoToSettlement(settlementGoingTo);
+                    }
+                }
+
+            }
+            for (int i = 0; i < toRemove.Count; i++){
+                registeredTravellers.Remove(toRemove[i]);
+            }
+        }
+
+        private List<Traveller> registeredTravellers = new List<Traveller>();
+
+        private Traveller GetTraveller(MobileParty mb)
+        {
+            var traveller = registeredTravellers.FirstOrDefault((p) => p.travellerParty == mb);
+            return traveller;
+        }
+
+        struct Traveller
+        {
+            public MobileParty travellerParty;
+            public Settlement homeSettlement;
+
+            public Traveller(MobileParty mb, Settlement s)
+            {
+                travellerParty = mb;
+                homeSettlement = s;
+            }
+        }
+
+        #region Registration and AI Manager Integration
+
+        public bool RegisterParty(MobileParty mb, Settlement s)
+        {
+            var behaviours = AI.AIManager.GetAIBehavioursForParty(mb);
+            foreach (var b in behaviours)
+            {
+                if (!b.IsCompatible(this))
+                    return false;
+            }
+            var travellerInstance = GetTraveller(mb);
+            // might need this in the future, cant be assed right now
+            //if (travellerInstance.travellerParty != null && travellerInstance.settlementGoingTo == s)
+            //{
+            //    ErrorHandler.HandleException(new Exception("The same mobile party cannot patrol around two different settlements!"));
+            //}
+            if (travellerInstance.homeSettlement == s)
+                return false;
+            registeredTravellers.Add(new Traveller(mb, s));
+            ModDebug.ShowMessage(mb.StringId + " is attempting to go to settlement " + s.Name, DebugMessageType.AI);
+            AIManager.RegisterAIBehaviour(mb, this);
+            return true;
+        }
+
+        #endregion
+
+        #region IAIBehaviour Implementation
+
+        public bool IsCompatible(IAIBehaviour AIBehaviour, bool secondCall)
+        {
+            if (AIBehaviour is PatrolAroundClosestLestInterruptedAndSwitchBehaviour || AIBehaviour is HourlyPatrolAroundSpawnBehaviour || AIBehaviour is HourlyGoToSettlementBehaviour)
+                return false;
+            return secondCall? true : AIBehaviour.IsCompatible(this, true);
+        }
+
+        #endregion
+    }
+}

--- a/AI/HourlyPatrolAroundSpawnBehaviour.cs
+++ b/AI/HourlyPatrolAroundSpawnBehaviour.cs
@@ -96,7 +96,7 @@ namespace CustomSpawns.AI
 
         public bool IsCompatible(IAIBehaviour AIBehaviour, bool secondCall)
         {
-            if (AIBehaviour is PatrolAroundClosestLestInterruptedAndSwitchBehaviour || AIBehaviour is HourlyPatrolAroundSpawnBehaviour)
+            if (AIBehaviour is PatrolAroundClosestLestInterruptedAndSwitchBehaviour || AIBehaviour is HourlyPatrolAroundSpawnBehaviour || AIBehaviour is HourlyGoToSettlementBehaviour)
                 return false;
             return secondCall? true : AIBehaviour.IsCompatible(this, true);
         }

--- a/AI/PatrolAroundClosestLestInterruptedAndSwitchBehaviour.cs
+++ b/AI/PatrolAroundClosestLestInterruptedAndSwitchBehaviour.cs
@@ -112,7 +112,7 @@ namespace CustomSpawns.AI
 
         public bool IsCompatible(IAIBehaviour AIBehaviour, bool secondCall)
         {
-            if (AIBehaviour is HourlyPatrolAroundSpawnBehaviour || AIBehaviour is PatrolAroundClosestLestInterruptedAndSwitchBehaviour)
+            if (AIBehaviour is HourlyPatrolAroundSpawnBehaviour || AIBehaviour is PatrolAroundClosestLestInterruptedAndSwitchBehaviour || AIBehaviour is HourlyGoToSettlementBehaviour)
                 return false;
             return secondCall ? true : AIBehaviour.IsCompatible(this, true);
         }

--- a/Data/SpawnData.cs
+++ b/Data/SpawnData.cs
@@ -169,6 +169,9 @@ namespace CustomSpawns.Data
 
                     dat.AttackClosestIfIdleForADay = node["AttackClosestIfIdleForADay"] == null ? true : bool.Parse(node["AttackClosestIfIdleForADay"].InnerText);
 
+                    dat.GoToSettlement = node["TravelToRandomTowns"] == null ? true : bool.Parse(node["TravelToRandomTowns"].InnerText);
+                    dat.PartyIsUnaggressive = node["PartyIsUnaggressive"] == null ? false : bool.Parse(node["PartyIsUnaggressive"].InnerText);
+
                     //try spawn at list creation
                     if (node["TrySpawnAt"] != null && node["TrySpawnAt"].InnerText != "")
                     {
@@ -380,6 +383,8 @@ namespace CustomSpawns.Data
         private float chanceOfSpawn;
         public int MinimumNumberOfDaysUntilSpawn { get; set; }
         public bool AttackClosestIfIdleForADay { get; set; }
+        public bool GoToSettlement { get; set; }
+        public bool PartyIsUnaggressive { get; set; }
         public AI.PatrolAroundClosestLestInterruptedAndSwitchBehaviour.PatrolAroundClosestLestInterruptedAndSwitchBehaviourData PatrolAroundClosestLestInterruptedAndSwitch { get; set; }
         public float ChanceOfSpawn
         {

--- a/Main.cs
+++ b/Main.cs
@@ -99,6 +99,7 @@ namespace CustomSpawns
                 starter.AddBehavior(new Spawn.SpawnBehaviour(Data.SpawnDataManager.Instance));
                 starter.AddBehavior(new AI.HourlyPatrolAroundSpawnBehaviour());
                 starter.AddBehavior(new AI.AttackClosestIfIdleForADayBehaviour());
+                starter.AddBehavior(new AI.HourlyGoToSettlementBehaviour());
                 starter.AddBehavior(new AI.PatrolAroundClosestLestInterruptedAndSwitchBehaviour());
                 starter.AddBehavior(new Diplomacy.ForcedWarPeaceBehaviour());
                 starter.AddBehavior(new Diplomacy.ForceNoKingdomBehaviour());

--- a/Spawn/Spawner.cs
+++ b/Spawn/Spawner.cs
@@ -13,6 +13,7 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
 using Helpers;
 using TaleWorlds.ObjectSystem;
+using CustomSpawns.Data;
 
 namespace CustomSpawns.Spawn
 {
@@ -111,6 +112,16 @@ namespace CustomSpawns.Spawn
                         new AI.PatrolAroundClosestLestInterruptedAndSwitchBehaviour.PatrolAroundClosestLestInterruptedAndSwitchBehaviourData(mb, data.PatrolAroundClosestLestInterruptedAndSwitch));
                     aiRegistrations.Add("Patrol Around Closest Lest Interrupted And Switch Behaviour: ", success);
                     invalid = invalid ? true : !success;
+                }
+                if (data.GoToSettlement)
+                {
+                    bool success = AI.AIManager.HourlyGoToSettlement.RegisterParty(mb, spawnedSettlement);
+                    aiRegistrations.Add("Go to settlement behavior: ", success);
+                    invalid = invalid ? true : !success;
+                }
+                if (data.PartyIsUnaggressive)
+                {
+                    mb.Aggressiveness = 0f;
                 }
                 if (invalid && ConfigLoader.Instance.Config.IsDebugMode)
                 {


### PR DESCRIPTION
[DO NOT MERGE, VERY WIP]
Introduces a new AI behavior for selecting random settlements among a spawn's culture and making it travel to them. Intended to further pave the way for ambient spawns. Also adds the ability to mark a party unaggressive. An unaggressive party (aggressiveness of 0) will never attack enemy parties or engage in raids.

Known issues:
- Sometimes the HourlyTickEvent doesn't fire/isn't caught and parties just stay idle or have other various issues (this appears to be an issue with the base game, as other behaviors which rely on the DailyTickEvent or HourlyTickEvent in CS also seem to have this problem, sometimes taking days to even fire.)
- After a few days (in testing around 10) the parties under this AI behavior will randomly begin to abandon their orders and change their behavior to "Going to a point," and all the spawns of a certain culture will end up amassing around a certain place, in testing it appears to be a hideout
- Not well tested, obviously

I plan to continue to add to this branch as I go on until I think it's ready for review. The purpose of this PR is to make the work public so if I can't figure something out, it doesn't go to waste.