### PR TITLE
Adds spawning at kingdoms rather for daily spawns

### DIFF
--- a/Data/SpawnData.cs
+++ b/Data/SpawnData.cs
@@ -119,6 +119,21 @@ namespace CustomSpawns.Data
                         i++;
                     }
 
+                    string sc = "overriden_spawn_kingdom";
+                    while (true)
+                    {
+                        string s1 = sc + "_" + i.ToString();
+                        if (node.Attributes[s1] == null || node.Attributes[s1].InnerText == "")
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            dat.OverridenSpawnKingdoms.Add((Kingdom)MBObjectManager.Instance.ReadObjectReferenceFromXml(s1, typeof(Kingdom), node));
+                        }
+                        i++;
+                    }
+
                     int j = 0;
                     string st = "overriden_spawn_culture";
                     while (true)
@@ -373,6 +388,7 @@ namespace CustomSpawns.Data
         public Clan SpawnClan { get; set; }
         public List<SpawnSettlementType> TrySpawnAtList = new List<SpawnSettlementType>();
         public List<Clan> OverridenSpawnClan = new List<Clan>();
+        public List<Kingdom> OverridenSpawnKingdoms = new List<Kingdom>();
         public List<Settlement> OverridenSpawnSettlements = new List<Settlement>();
         public List<CultureCode> OverridenSpawnCultures = new List<CultureCode>();
         public List<AccompanyingParty> SpawnAlongWith = new List<AccompanyingParty>();

--- a/Main.cs
+++ b/Main.cs
@@ -18,7 +18,7 @@ namespace CustomSpawns
     public class Main : MBSubModuleBase
     {
         public static readonly string version = "v1.3.1";
-        public static readonly bool isAPIMode = false;
+        public static readonly bool isAPIMode = true;
         public static CustomSpawnsCustomSpeedModel customSpeedModel;
 
         private static bool removalMode = false;

--- a/Main.cs
+++ b/Main.cs
@@ -18,7 +18,7 @@ namespace CustomSpawns
     public class Main : MBSubModuleBase
     {
         public static readonly string version = "v1.3.1";
-        public static readonly bool isAPIMode = true;
+        public static readonly bool isAPIMode = false;
         public static CustomSpawnsCustomSpeedModel customSpeedModel;
 
         private static bool removalMode = false;

--- a/Spawn/Spawner.cs
+++ b/Spawn/Spawner.cs
@@ -159,6 +159,10 @@ namespace CustomSpawns.Spawn
                 //spawn at overriden spawn instead!
                 spawnOverride = CampaignUtils.PickRandomSettlementOfCulture(data.OverridenSpawnCultures, data.TrySpawnAtList);
             }
+            if (spawnOverride == null && data.OverridenSpawnKingdoms.Count != 0)
+            {
+                spawnOverride = CampaignUtils.PickRandomSettlementOfKingdom(data.OverridenSpawnKingdoms, data.TrySpawnAtList);
+            }
             //get settlement
             Settlement spawnSettlement = ConfigLoader.Instance.Config.SpawnAtOneHideout ? firstHideout : (spawnOverride == null ? CampaignUtils.GetPreferableHideout(spawnClan) : spawnOverride);
             return spawnSettlement;

--- a/Utils/CampaignUtils.cs
+++ b/Utils/CampaignUtils.cs
@@ -91,7 +91,7 @@ namespace CustomSpawns
             return permissible.Count == 0 ? Settlement.All[0] : permissible[0];
         }
 
-        public static Settlement PickRandomSettlementOfKingdom(List<Kingdom> f, List<Data.SpawnSettlementType> preferredTypes = null)
+        public static Settlement PickRandomSettlementOfKingdom(List<Kingdom> f, List<Data.SpawnSettlementType> preferredTypes = null) //instead of PicKRandomSettlementOfCulture, does not prioritize types over kingdom
         {
             int num = 0;
             List<Settlement> permissible = new List<Settlement>();
@@ -99,18 +99,25 @@ namespace CustomSpawns
             {
                 foreach (Settlement s in Settlement.All)
                 {
-                    foreach (var type in preferredTypes)
+                    if (f.Contains(s.MapFaction))
                     {
-                        if (SettlementIsOfValidType(s, type))
+                        foreach (var type in preferredTypes)
                         {
-                            permissible.Add(s);
-                            break;
+                            if (SettlementIsOfValidType(s, type))
+                            {
+                                permissible.Add(s);
+                                break;
+                            }
                         }
                     }
                 }
             }
             if (permissible.Count == 0)
             {
+                if (preferredTypes != null)
+                {
+                    ModDebug.ShowMessage("Spawn type checking for kingdom spawn did not find any valid settlements. Falling back to kingdom.", DebugMessageType.Spawn);
+                }
                 foreach (Settlement s in Settlement.All)
                 {
                     if ((s.IsTown || s.IsVillage) && f.Contains(s.MapFaction))

--- a/Utils/CampaignUtils.cs
+++ b/Utils/CampaignUtils.cs
@@ -91,6 +91,54 @@ namespace CustomSpawns
             return permissible.Count == 0 ? Settlement.All[0] : permissible[0];
         }
 
+        public static Settlement PickRandomSettlementOfKingdom(List<Kingdom> f, List<Data.SpawnSettlementType> preferredTypes = null)
+        {
+            int num = 0;
+            List<Settlement> permissible = new List<Settlement>();
+            if (preferredTypes != null)
+            {
+                foreach (Settlement s in Settlement.All)
+                {
+                    foreach (var type in preferredTypes)
+                    {
+                        if (SettlementIsOfValidType(s, type))
+                        {
+                            permissible.Add(s);
+                            break;
+                        }
+                    }
+                }
+            }
+            if (permissible.Count == 0)
+            {
+                foreach (Settlement s in Settlement.All)
+                {
+                    if ((s.IsTown || s.IsVillage) && f.Contains(s.MapFaction))
+                    {
+                        permissible.Add(s);
+                    }
+                }
+            }
+            permissible.Randomize();
+            foreach (Settlement s in permissible)
+            {
+                int num2 = TaleWorldsCode.BanditsCampaignBehaviour.CalculateDistanceScore(s.Position2D.DistanceSquared(MobileParty.MainParty.Position2D));
+                num += num2;
+            }
+            int num3 = MBRandom.RandomInt(num);
+            foreach (Settlement s in permissible)
+            {
+                int num4 = TaleWorldsCode.BanditsCampaignBehaviour.CalculateDistanceScore(s.Position2D.DistanceSquared(MobileParty.MainParty.Position2D)); //makes it more likely that the spawn will be further to the player.
+                num3 -= num4;
+                if (num3 <= 0)
+                {
+                    return s;
+                }
+            }
+            ModDebug.ShowMessage("Unable to find proper faction settlement of" + f.ToString() + " for some reason.", DebugMessageType.Spawn);
+            return permissible.Count == 0 ? Settlement.All[0] : permissible[0];
+        }
+
         public static Clan GetClanWithName(string name)
         {
             foreach (Clan c in Clan.All)


### PR DESCRIPTION
Allows daily spawns to spawn specifically within the political borders of a kingdom. Useful for some stuff like guards or ambient spawns, like "Vlandian Page" or somesuch. Uses the `overriden_spawn_kingdom_#` key.