### PR TITLE
Fix for crashes related to "Bamboo Shaft" handle for Pikes

### DIFF
--- a/CustomSpawns/_Module/ModuleData/WeaponDescriptions.xslt
+++ b/CustomSpawns/_Module/ModuleData/WeaponDescriptions.xslt
@@ -61,7 +61,10 @@
 
     <xsl:variable name="javelin-pieces" select="'cs_bamboo_spear_handle'"/>
 
-    <xsl:variable name="pike-pieces" select="'cs_barbarian_pike_shaft'"/>
+    <xsl:variable name="pike-pieces" select="concat(
+					'cs_barbarian_pike_shaft,', 
+					'spear_handle_3'
+				)"/>
 
     <xsl:variable name="two-handed-axe-pieces" select="'cs_pick_head'"/>
     


### PR DESCRIPTION
Caused crash on entering smithy with available crafting order for Pikes & crash on selecting "Bamboo Shaft" handle when crafting Pikes.

Still saw crafting orders for Pikes valued at 0 gold, happens rarely though.