### PR TITLE
Fixed smithing crashes for "Tzikurion head" (2h axe), "Cataphracts Mace Head" & "Steel Horsemans Mace Handle" (2h mace)

### DIFF
--- a/CustomSpawns/_Module/ModuleData/WeaponDescriptions.xslt
+++ b/CustomSpawns/_Module/ModuleData/WeaponDescriptions.xslt
@@ -57,7 +57,7 @@
             'cs_ls_morningstar_shaft,',
             'cs_club_handle,',
             'cs_no_head,',
-			'mace_head_7',
+			'mace_head_7,',
 			'mace_handle_15'
         )"/>
 

--- a/CustomSpawns/_Module/ModuleData/WeaponDescriptions.xslt
+++ b/CustomSpawns/_Module/ModuleData/WeaponDescriptions.xslt
@@ -56,7 +56,9 @@
             'cs_s_morningstar_shaft,',
             'cs_ls_morningstar_shaft,',
             'cs_club_handle,',
-            'cs_no_head'
+            'cs_no_head,',
+			'mace_head_7',
+			'mace_handle_15'
         )"/>
 
     <xsl:variable name="javelin-pieces" select="'cs_bamboo_spear_handle'"/>
@@ -66,7 +68,10 @@
 					'spear_handle_3'
 				)"/>
 
-    <xsl:variable name="two-handed-axe-pieces" select="'cs_pick_head'"/>
+    <xsl:variable name="two-handed-axe-pieces" select="concat(
+					'cs_pick_head,',
+					'axe_craft_26_head'
+				)"/>
     
     <xsl:variable name="two-handed-polearm-pieces" select="concat(
                     'cs_halberd_head,',


### PR DESCRIPTION
Smithing: fixed crash on selecting "Tzikurion head" (axe_craft_26_head) for two handed axes and "Cataphracts Mace Head" (mace_head_7) & "Steel Horsemans Mace Handle" (mace_handle_15) for two handed maces

Pretty sure I checked all blades, head pieces and handles for all weapons except for Daggers, didn't check pommels or guards (thoroughly) though